### PR TITLE
feature: skip certificate verification

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -42,6 +42,18 @@ provider "edgeadc" {
 }
 ```
 
+Note - `skip_cert_verification` can be set to `true` to ignore certificate verification.
+* This is especially useful for initial bootstrapping as it will allow you to use the provider with the out-of-the-box self-signed certificate without having to import the self-signed certificate into your trust store.
+```hcl
+provider "edgeadc" {
+  username = "admin"
+  password = "jetnexus"
+  endpoint = "https://192.168.2.101:443"
+  skip_cert_verification = true
+}
+```
+
+
 ## Examples
 - [See examples directory](/examples/main.tf)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,4 +19,5 @@ description: |-
 
 - `endpoint` (String) EdgeADC Endpoint
 - `password` (String) API Password
+- `skip_cert_verification` (Boolean) Whether to skip TLS verification
 - `username` (String) API Username


### PR DESCRIPTION
Signed-off-by: smcavallo <smcavallo@hotmail.com>

<!--
Thank you for helping to improve 'terraform-provider-edgeadc'
-->

### Description of your changes

Add `skip_cert_verification` to ignore certificate verification.
* This is especially useful for initial bootstrapping as it will allow you to use the provider with the out-of-the-box self-signed certificate without having to import the self-signed certificate into your trust store.
```hcl
provider "edgeadc" {
  username = "admin"
  password = "jetnexus"
  endpoint = "https://192.168.2.101:443"
  skip_cert_verification = true
}
```

This fixes the below behavior when trying to connect to a device with the built-in self-signed cert:
```
│ Error: Unable to Read User
│
│   with edgeadc_users.test_api_user,
│   on main.tf line 21, in resource "edgeadc_users" "test_api_user":
│   21: resource "edgeadc_users" "test_api_user" {
│
│ error: do request: error: creating cookie response: Post "https://192.168.2.101:443/POST/32": tls: failed to verify
│ certificate: x509: certificate signed by unknown authority
```

With the above feature when setting `skip_cert_verification` to `true` it is possible to bypass this warning and continue configuring the device.

Fixes #

I have:

- [x] Read and followed the contribution process].
- [x] Run all unit tests to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
