### PR TITLE
feature: improve ip_services plan performance

### DIFF
--- a/internal/provider/edgeadc_api.go
+++ b/internal/provider/edgeadc_api.go
@@ -17,6 +17,8 @@ import (
 	"strings"
 	"time"
 
+	"terraform-provider-edgeadc/swagger"
+
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
@@ -37,6 +39,10 @@ type API struct {
 	cookieGuid     string
 	loggingContext context.Context
 	mutexKV        *MutexKV
+
+	// Cache for Read-Phase ONLY for performance
+	cachedIpServices     swagger.IpServices
+	cachedIpServiceCombo swagger.IpServicescombo
 }
 
 type LoginResponse struct {
@@ -62,6 +68,9 @@ func NewAPI(baseURL, username, password, hostPort string) *API {
 		loggingContext: context.Background(),
 		// Set a mutexKV to prevent concurrent requests which can be used globally
 		mutexKV: NewMutexKV(),
+		// Initialize a new cache for the API
+		cachedIpServices:     swagger.IpServices{},
+		cachedIpServiceCombo: swagger.IpServicescombo{},
 	}
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS12},


### PR DESCRIPTION
<!--
Thank you for helping to improve 'terraform-provider-edgeadc'
-->

### Description of your changes
When running `terraform plan` - each resource makes a separate request to the API to retrieve it's state.
Since a single API call returns the entire list of ip services, we can retrieve all the data once and referenced that cached data to generate the plan.
This drastically improves performance and allows `terraform plan` performance to scale


<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve open issues. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [X ] Read and followed the contribution process].
- [X ] Run all unit tests to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
