### PR TITLE
Provider state inconsistencies

### DIFF
--- a/internal/provider/ip_services_resource.go
+++ b/internal/provider/ip_services_resource.go
@@ -347,7 +347,12 @@ func CachedReadIPService(ipServices swagger.IpServices, ipServicesCombo swagger.
 	}
 
 	comboOptions := *ipServicesCombo.MonitorPolicyCombo.Options
-	serverMonitoring, _ := ConvertComboOptionsToNames(comboOptions, model.ServerMonitoring)
+	serverMonitoring, convertErr := ConvertComboOptionsToNames(comboOptions, model.ServerMonitoring)
+	if convertErr != nil {
+		// If conversion fails, keep the raw IDs to avoid losing data
+		// This can happen if the combo options are stale or incomplete
+		return model, nil
+	}
 
 	model.ServerMonitoring = serverMonitoring
 	return model, nil
@@ -388,7 +393,11 @@ func ReadIPService(client *API, ipAddr string, port string) (swagger.IpService, 
 		return model, comboErr
 	}
 	comboOptions := *ipServicesCombo.MonitorPolicyCombo.Options
-	serverMonitoring, _ := ConvertComboOptionsToNames(comboOptions, model.ServerMonitoring)
+	serverMonitoring, convertErr := ConvertComboOptionsToNames(comboOptions, model.ServerMonitoring)
+	if convertErr != nil {
+		// If conversion fails, keep the raw IDs to avoid losing data
+		return model, nil
+	}
 
 	model.ServerMonitoring = serverMonitoring
 	return model, nil
@@ -489,7 +498,10 @@ func UpdateIpServiceBasicTab(client *API, model swagger.UpdateBasicTab) error {
 		return comboErr
 	}
 	comboOptions := *ipServicesCombo.MonitorPolicyCombo.Options
-	serverMonitoring, _ := ConvertComboOptionsToIds(comboOptions, model.ServerMonitoring)
+	serverMonitoring, convertErr := ConvertComboOptionsToIds(comboOptions, model.ServerMonitoring)
+	if convertErr != nil {
+		return fmt.Errorf("unable to convert server monitoring names to IDs: %w", convertErr)
+	}
 	model.ServerMonitoring = serverMonitoring
 
 	// Update
@@ -640,47 +652,44 @@ func ToUpdateBasicTab(data resource_ip_services.IpServicesResourceModel) swagger
 }
 
 // MergeBasicTabs merges the basic tabs with the initial terraform value
-// It overlays values from terraform only when the value is known
-// ToDo: Is there a better way to handle this?
+// It overlays values from terraform only when the value is known and not null
 func MergeBasicTabs(input swagger.UpdateBasicTab, data resource_ip_services.IpServicesResourceModel) swagger.UpdateBasicTab {
-	assignIfKnown := func(target *string, source types.String) {
-		if !source.IsUnknown() {
+	assignIfSet := func(target *string, source types.String) {
+		if !source.IsUnknown() && !source.IsNull() {
 			*target = source.ValueString()
 		}
 	}
-	assignIfKnown(&input.ServerMonitoring, data.ServerMonitoring)
-	assignIfKnown(&input.Acceleration, data.Acceleration)
-	assignIfKnown(&input.LoadBalancingPolicy, data.LoadBalancingPolicy)
-	assignIfKnown(&input.SslCertificate, data.SslCertificate)
-	assignIfKnown(&input.SslClientCertificate, data.SslClientCertificate)
-	assignIfKnown(&input.CachingRule, data.CachingRule)
+	assignIfSet(&input.ServerMonitoring, data.ServerMonitoring)
+	assignIfSet(&input.Acceleration, data.Acceleration)
+	assignIfSet(&input.LoadBalancingPolicy, data.LoadBalancingPolicy)
+	assignIfSet(&input.SslCertificate, data.SslCertificate)
+	assignIfSet(&input.SslClientCertificate, data.SslClientCertificate)
+	assignIfSet(&input.CachingRule, data.CachingRule)
 
 	return input
 }
 
 // MergeAdvanceTabs merges the advance tabs with the initial terraform value
-// It overlays values from terraform only when the value is known
-// ToDo: Is there a better way to handle this?
+// It overlays values from terraform only when the value is known and not null
 func MergeAdvanceTabs(input swagger.UpdateAdvanceTab, data resource_ip_services.IpServicesResourceModel) swagger.UpdateAdvanceTab {
-	assignIfKnown := func(target *string, source types.String) {
-		if !source.IsUnknown() {
+	assignIfSet := func(target *string, source types.String) {
+		if !source.IsUnknown() && !source.IsNull() {
 			*target = source.ValueString()
 		}
 	}
-	assignIfKnown(&input.Connectivity, data.Connectivity)
-	assignIfKnown(&input.ConnectionTimeout, data.ConnectionTimeout)
-	assignIfKnown(&input.MonitoringInterval, data.MonitoringInterval)
-	assignIfKnown(&input.MonitoringTimeout, data.MonitoringTimeout)
-	assignIfKnown(&input.MaxConn, data.MaxConn)
-	assignIfKnown(&input.InCount, data.InCount)
-	assignIfKnown(&input.OutCount, data.OutCount)
-	assignIfKnown(&input.InCount, data.InCount)
-	assignIfKnown(&input.CipherName, data.CipherName)
-	assignIfKnown(&input.SecurityLog, data.SecurityLog)
-	assignIfKnown(&input.SslRenegotiation, data.SslRenegotiation)
-	assignIfKnown(&input.SNIDefaultCertificateName, data.SNIDefaultCertificateName)
-	assignIfKnown(&input.SslResumption, data.SslResumption)
-	assignIfKnown(&input.Offlinonfailure, data.Offlinonfailure)
+	assignIfSet(&input.Connectivity, data.Connectivity)
+	assignIfSet(&input.ConnectionTimeout, data.ConnectionTimeout)
+	assignIfSet(&input.MonitoringInterval, data.MonitoringInterval)
+	assignIfSet(&input.MonitoringTimeout, data.MonitoringTimeout)
+	assignIfSet(&input.MaxConn, data.MaxConn)
+	assignIfSet(&input.InCount, data.InCount)
+	assignIfSet(&input.OutCount, data.OutCount)
+	assignIfSet(&input.CipherName, data.CipherName)
+	assignIfSet(&input.SecurityLog, data.SecurityLog)
+	assignIfSet(&input.SslRenegotiation, data.SslRenegotiation)
+	assignIfSet(&input.SNIDefaultCertificateName, data.SNIDefaultCertificateName)
+	assignIfSet(&input.SslResumption, data.SslResumption)
+	assignIfSet(&input.Offlinonfailure, data.Offlinonfailure)
 
 	// ToDo: Enable once the API is updated
 	input.ServerProxyProtocolVariant = "none"

--- a/internal/provider/resource_ip_services/ip_services_resource_manual.go
+++ b/internal/provider/resource_ip_services/ip_services_resource_manual.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -44,10 +45,16 @@ func IpServiceResourceSchema(ctx context.Context) schema.Schema {
 			"interface_key": schema.StringAttribute{
 				Optional: true,
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"channel_key": schema.StringAttribute{
 				Optional: true,
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"ip_addr": schema.StringAttribute{
 				Required: true,
@@ -67,22 +74,41 @@ func IpServiceResourceSchema(ctx context.Context) schema.Schema {
 			"service_name": schema.StringAttribute{
 				Optional: true,
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"local_port_enabled_checked": schema.StringAttribute{
 				Optional: true,
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
+			// primary_checked controls whether the VIP is Active or Passive.
+			// The API normalizes empty strings to "Passive", so we default
+			// to "Passive" to avoid inconsistent state after apply.
 			"primary_checked": schema.StringAttribute{
 				Optional: true,
 				Computed: true,
+				Default:  stringdefault.StaticString("Passive"),
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"service_type": schema.StringAttribute{
 				Optional: true,
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"max_conn": schema.StringAttribute{
 				Optional: true,
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"port": schema.StringAttribute{
 				Required: true,
@@ -91,35 +117,59 @@ func IpServiceResourceSchema(ctx context.Context) schema.Schema {
 			"offlinonfailure": schema.StringAttribute{
 				Optional: true,
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"content_server_group_name": schema.StringAttribute{
 				Optional: true,
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"enable_connection_pool": schema.StringAttribute{
 				Optional: true,
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"connection_pool_size": schema.StringAttribute{
 				Optional: true,
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"server_monitoring": schema.StringAttribute{
 				Optional:    true,
 				Computed:    true,
 				Description: "Comma-separated list of custom monitor names",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"load_balancing_policy": schema.StringAttribute{
 				Optional: true,
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"connectivity": schema.StringAttribute{
 				Optional: true,
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"acceleration": schema.StringAttribute{
 				Optional: true,
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"ssl_certificate": schema.StringAttribute{
 				Optional: true,
@@ -131,50 +181,86 @@ func IpServiceResourceSchema(ctx context.Context) schema.Schema {
 			"ssl_client_certificate": schema.StringAttribute{
 				Optional: true,
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"caching_rule": schema.StringAttribute{
 				Optional: true,
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"monitoring_interval": schema.StringAttribute{
 				Optional: true,
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"monitoring_timeout": schema.StringAttribute{
 				Optional: true,
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"connection_timeout": schema.StringAttribute{
 				Optional: true,
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"in_count": schema.StringAttribute{
 				Optional: true,
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"out_count": schema.StringAttribute{
 				Optional: true,
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"cipher_name": schema.StringAttribute{
 				Optional: true,
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"sni_default_certificate_name": schema.StringAttribute{
 				Optional: true,
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"ssl_renegotiation": schema.StringAttribute{
 				Optional: true,
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"ssl_resumption": schema.StringAttribute{
 				Optional: true,
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"security_log": schema.StringAttribute{
 				Optional: true,
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			//"flight_path": schema.ObjectAttribute{
 			//	Optional:       true,

--- a/internal/provider/resource_server/server_resource_manual.go
+++ b/internal/provider/resource_server/server_resource_manual.go
@@ -46,6 +46,9 @@ func ServerResourceSchema(ctx context.Context) schema.Schema {
 			"server_key": schema.StringAttribute{
 				Optional: true,
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"c_id": schema.StringAttribute{
 				Optional: false,
@@ -58,6 +61,9 @@ func ServerResourceSchema(ctx context.Context) schema.Schema {
 			"cs_activity": schema.StringAttribute{
 				Optional: true,
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"cs_ip_addr": schema.StringAttribute{
 				Required: true,
@@ -70,6 +76,9 @@ func ServerResourceSchema(ctx context.Context) schema.Schema {
 			"cs_notes": schema.StringAttribute{
 				Optional: true,
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"cs_monitor_end_point": schema.StringAttribute{
 				Optional: true,
@@ -79,10 +88,16 @@ func ServerResourceSchema(ctx context.Context) schema.Schema {
 			"server_id": schema.StringAttribute{
 				Optional: true,
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"weight_factor": schema.StringAttribute{
 				Optional: true,
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 		},
 	}

--- a/internal/provider/server_resource.go
+++ b/internal/provider/server_resource.go
@@ -197,10 +197,10 @@ func (r *serverResource) Update(ctx context.Context, req resource.UpdateRequest,
 	r.client.mutexKV.Lock(lockName)
 	defer r.client.mutexKV.Unlock(lockName)
 
-	// Update API call logic
-	model := r.ToCServerId(data)
+	// Update API call logic - use ToUpdateServer to pass all field values
+	updateModel := r.ToUpdateServer(data)
 	ipServiceIpAddr, ipServicePort, _ := GetAddressAndPortFromId(data.IpService.ValueString())
-	err := UpdateServer(r.client, model, ipServiceIpAddr, ipServicePort)
+	err := UpdateServer(r.client, updateModel, ipServiceIpAddr, ipServicePort)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Update Server",
@@ -209,19 +209,19 @@ func (r *serverResource) Update(ctx context.Context, req resource.UpdateRequest,
 		return
 	}
 
-	ipService, cServerId, finalErr := ReadServer(r.client, model.CSIPAddr, model.CSPort, ipServiceIpAddr, ipServicePort)
+	ipService, cServerId, finalErr := ReadServer(r.client, updateModel.CSIPAddr, updateModel.CSPort, ipServiceIpAddr, ipServicePort)
 	if finalErr != nil {
 		resp.Diagnostics.AddError(
-			"Unable to Read Created Server",
+			"Unable to Read Updated Server",
 			finalErr.Error(),
 		)
 		return
 	}
-    // keep previous monitor endpoint from plan across update
-    prevMonitor := data.CSMonitorEndPoint
-    data = r.FromCServerId(cServerId, ipService.InterfaceID, ipService.ChannelID)
-    data.IpService = types.StringValue(ipServiceId)
-    data.CSMonitorEndPoint = prevMonitor
+	// keep previous monitor endpoint from plan across update
+	prevMonitor := data.CSMonitorEndPoint
+	data = r.FromCServerId(cServerId, ipService.InterfaceID, ipService.ChannelID)
+	data.IpService = types.StringValue(ipServiceId)
+	data.CSMonitorEndPoint = prevMonitor
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -331,23 +331,22 @@ func UpdateServerTemplate(client *API, updateServer swagger.UpdateServer, ipServ
 	return nil
 }
 
-func UpdateServer(client *API, model swagger.CServerId, ipServiceIpAddr string, ipServicePort string) error {
-	// Refresh server details
-	ipService, cServer, readErr := ReadServer(client, model.CSIPAddr, model.CSPort, ipServiceIpAddr, ipServicePort)
+func UpdateServer(client *API, updateServer swagger.UpdateServer, ipServiceIpAddr string, ipServicePort string) error {
+	// Refresh server details to get the correct IDs
+	ipService, cServer, readErr := ReadServer(client, updateServer.CSIPAddr, updateServer.CSPort, ipServiceIpAddr, ipServicePort)
 	if readErr != nil {
 		return readErr
 	}
-	// Update details
+	// Set the correct IDs from the refreshed data
 	// Note this is subject to race condition/concurrent operation scenario
 	// As the ID could change between when we read the data and when we create the server
-	updateServer := swagger.UpdateServer{}
 	updateServer.EditedInterface = ipService.InterfaceID
 	updateServer.EditedChannel = ipService.ChannelID
 	updateServer.CId = cServer.CId
 
-	// Update the server
-    jsonBytes, _ := json.Marshal(updateServer)
-    _, err := client.PostEdgeADCApi("/POST/9?iAction=2&iType=2", jsonBytes)
+	// Update the server with all field values
+	jsonBytes, _ := json.Marshal(updateServer)
+	_, err := client.PostEdgeADCApi("/POST/9?iAction=2&iType=2", jsonBytes)
 	if err != nil {
 		return err
 	}

--- a/internal/provider/server_resource.go
+++ b/internal/provider/server_resource.go
@@ -453,7 +453,7 @@ func GetServerByAddressAndPortFromIpServices(ipServices swagger.IpServices, ipSe
 			}
 		}
 	}
-	return swagger.IpService{}, swagger.CServerId{}, errors.New(fmt.Sprintf("%s with %s:%s for ip_service %s:%s", errServerNotFound, serverPort, ipServiceIpAddr, ipServicePort))
+	return swagger.IpService{}, swagger.CServerId{}, errors.New(fmt.Sprintf("%s with %s:%s for ip_service %s:%s", errServerNotFound, serverIpAddr, serverPort, ipServiceIpAddr, ipServicePort))
 }
 
 func GetServerByAddressAndPortFromIpService(ipService swagger.IpService, ipServiceIpAddr string, ipServicePort string, serverIpAddr string, serverPort string) (swagger.CServerId, error) {


### PR DESCRIPTION
### Description of your changes

This PR addresses several customer-reported bugs related to inconsistent Terraform state and update failures in the `edgeadc_ip_services` and `edgeadc_server` resources.

Key issues resolved include:

*   **`primary_checked` inconsistency:** The `primary_checked` field in `ip_services` would report an inconsistent result after apply (e.g., `""` vs `"Passive"`). This is fixed by setting a default value and using `UseStateForUnknown()` to align Terraform's plan with the API's normalization behavior.
*   **Server resource update failures:** The `UpdateServer` function was incorrectly sending empty values for most fields, leading to server settings being reset on update. The update logic has been corrected to properly pass all configured field values.
*   **`server_monitoring` inconsistencies:** Conversion errors for server monitoring names/IDs were silently ignored, causing state drift. Error handling has been improved, and `UseStateForUnknown()` added.
*   **General `Optional+Computed` field inconsistencies:** Many `Optional+Computed` fields across both `ip_services` and `server` resources lacked `UseStateForUnknown()` plan modifiers. Additionally, merge functions for `ip_services` were not correctly handling null values, leading to API defaults being overwritten. These have been updated to ensure consistent state management.
*   **Pre-existing `go vet` error:** Fixed a format string mismatch in `GetServerByAddressAndPortFromIpServices`.

Fixes #

I have:

- [ ] Read and followed the contribution process].
- [ ] Run all unit tests to ensure this PR is ready for review.

### How has this code been tested

The project currently has no unit tests. The changes have been verified by:

*   Successful compilation (`go build ./...`).
*   Passing `go vet` checks.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-b979a3fe-3026-4ef9-9c7d-5890a26f8477"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b979a3fe-3026-4ef9-9c7d-5890a26f8477"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

